### PR TITLE
Add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Personally, I found the output from `git log --graph` difficult to read, even wi
 $ cargo install --locked serie
 ```
 
+### AUR (Arch Linux)
+
+```
+$ paru -S serie
+```
+
 ### Homebrew (macOS)
 
 ```


### PR DESCRIPTION
`serie` is now packaged in the AUR: <https://aur.archlinux.org/packages/serie>
