### PR TITLE
Correct default (non-XDG) config directory in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can see the keybindings by pressing the `?` key.
 ### Config
 
 If `$XDG_CONFIG_HOME/serie/config.toml` exists, it will be read and used.
-If `$XDG_CONFIG_HOME` is not set, `~/.cache/` will be used instead.
+If `$XDG_CONFIG_HOME` is not set, `~/.config/` will be used instead.
 
 If the config file does not exist, the default values will be used for all items.
 If the config file exists but some items are not set, the default values will be used for those unset items.


### PR DESCRIPTION
Closes #25, I think it was a mistake :)