### PR TITLE
Save current MSRV in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 keywords = ["git", "cli", "tui", "terminal"]
 categories = ["command-line-utilities"]
 edition = "2021"
+rust-version = "1.79.0"
 
 exclude = ["/.github", "/img"]
 


### PR DESCRIPTION
Closes #43

Both ravif and bitstream-io require Rust 1.79.0.
