### PR TITLE
Added "jump to parent commit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,20 +171,21 @@ The default key bindings can be overridden. Please refer to [default-keybind.tom
 
 #### Commit List
 
-| Key                               | Description                                        | Corresponding keybind                        |
-| --------------------------------- | -------------------------------------------------- | -------------------------------------------- |
-| <kbd>Down/Up</kbd> <kbd>j/k</kbd> | Move down/up                                       | `navigate_down` `navigate_up`                |
-| <kbd>g/G</kbd>                    | Go to top/bottom                                   | `go_to_top` `go_to_bottom`                   |
-| <kbd>Ctrl-f/b</kbd>               | Scroll page down/up                                | `page_down` `page_up`                        |
-| <kbd>Ctrl-d/u</kbd>               | Scroll half page down/up                           | `half_page_down` `half_page_up`              |
-| <kbd>Ctrl-e/y</kbd>               | Scroll down/up                                     | `scroll_down` `scroll_up`                    |
-| <kbd>H/M/L</kbd>                  | Select top/middle/bottom of the screen             | `select_top` `select_middle` `select_bottom` |
-| <kbd>Enter</kbd>                  | Show commit details<br>Apply search (if searching) | `confirm`                                    |
-| <kbd>Tab</kbd>                    | Open refs list                                     | `ref_list_toggle`                            |
-| <kbd>/</kbd>                      | Start search                                       | `search`                                     |
-| <kbd>Esc</kbd>                    | Cancel search                                      | `cancel`                                     |
-| <kbd>n/N</kbd>                    | Go to next/previous search match                   | `go_to_next` `go_to_previous`                |
-| <kbd>c/C</kbd>                    | Copy commit short/full hash                        | `short_copy` `full_copy`                     |
+| Key                                  | Description                                        | Corresponding keybind                        |
+| ------------------------------------ | -------------------------------------------------- | -------------------------------------------- |
+| <kbd>Down/Up</kbd> <kbd>j/k</kbd>    | Move down/up                                       | `navigate_down` `navigate_up`                |
+| <kbd>Alt-Down</kbd> <kbd>Alt-j</kbd> | Move to parent commit                              | `go_to_parent`                               |
+| <kbd>g/G</kbd>                       | Go to top/bottom                                   | `go_to_top` `go_to_bottom`                   |
+| <kbd>Ctrl-f/b</kbd>                  | Scroll page down/up                                | `page_down` `page_up`                        |
+| <kbd>Ctrl-d/u</kbd>                  | Scroll half page down/up                           | `half_page_down` `half_page_up`              |
+| <kbd>Ctrl-e/y</kbd>                  | Scroll down/up                                     | `scroll_down` `scroll_up`                    |
+| <kbd>H/M/L</kbd>                     | Select top/middle/bottom of the screen             | `select_top` `select_middle` `select_bottom` |
+| <kbd>Enter</kbd>                     | Show commit details<br>Apply search (if searching) | `confirm`                                    |
+| <kbd>Tab</kbd>                       | Open refs list                                     | `ref_list_toggle`                            |
+| <kbd>/</kbd>                         | Start search                                       | `search`                                     |
+| <kbd>Esc</kbd>                       | Cancel search                                      | `cancel`                                     |
+| <kbd>n/N</kbd>                       | Go to next/previous search match                   | `go_to_next` `go_to_previous`                |
+| <kbd>c/C</kbd>                       | Copy commit short/full hash                        | `short_copy` `full_copy`                     |
 
 #### Commit Detail
 

--- a/assets/default-keybind.toml
+++ b/assets/default-keybind.toml
@@ -8,6 +8,7 @@ navigate_up = ["k", "up"]
 navigate_down = ["j", "down"]
 navigate_right = ["l", "right"]
 navigate_left = ["h", "left"]
+go_to_parent = ["alt-j", "alt-down"]
 
 go_to_top = ["g"]
 go_to_bottom = ["shift-g"]

--- a/src/event.rs
+++ b/src/event.rs
@@ -96,6 +96,7 @@ pub enum UserEvent {
     NavigateLeft,
     GoToTop,
     GoToBottom,
+    GoToParent,
     ScrollUp,
     ScrollDown,
     PageUp,

--- a/src/view/help.rs
+++ b/src/view/help.rs
@@ -173,6 +173,7 @@ fn build_lines(keybind: &KeyBind) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
         &[
             (&[UserEvent::NavigateDown], "Move down"),
             (&[UserEvent::NavigateUp], "Move up"),
+            (&[UserEvent::GoToParent], "Go to parent"),
             (&[UserEvent::GoToTop], "Go to top"),
             (&[UserEvent::GoToBottom], "Go to bottom"),
             (&[UserEvent::PageDown], "Scroll page down"),

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -55,6 +55,9 @@ impl<'a> ListView<'a> {
                 UserEvent::NavigateUp => {
                     self.as_mut_list_state().select_prev();
                 }
+                UserEvent::GoToParent => {
+                    self.as_mut_list_state().select_parent();
+                }
                 UserEvent::GoToTop => {
                     self.as_mut_list_state().select_first();
                 }

--- a/src/widget/commit_list.rs
+++ b/src/widget/commit_list.rs
@@ -165,6 +165,23 @@ impl<'a> CommitListState<'a> {
         }
     }
 
+    pub fn select_parent(&mut self) {
+        let target_commit = self.selected_commit_parent_hash().clone();
+        while target_commit.as_str() != self.selected_commit_hash().as_str() {
+            self.select_next();
+        }
+    }
+
+    pub fn selected_commit_parent_hash(&self) -> &CommitHash {
+        let selected_commit_hash = self.selected_commit_hash();
+
+        self.commits[self.current_selected_index()]
+            .commit
+            .parent_commit_hashes
+            .first()
+            .unwrap_or(selected_commit_hash)
+    }
+
     pub fn select_prev(&mut self) {
         if self.selected > 0 {
             self.selected -= 1;


### PR DESCRIPTION
Inspired by Sublime Merge, use the <kbd>Alt-Down</kbd> key to jump to the parent commit.