### PR TITLE
DOCS: Include screen as the first typical multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The terminals on which each has been confirmed to work are listed below.
 ### Unsupported environments
 
 - Sixel graphics is not supported.
-- Terminal multiplexers (tmux, Zellij, etc.) are not supported.
+- Terminal multiplexers (screen, tmux, Zellij, etc.) are not supported.
 
 ## Contributing
 


### PR DESCRIPTION
Sadly in my testing serie does not work within screen either (to be expected).

Listing it first as its older than tmux etc, and still very widely used.