### PR TITLE
Fix check git work tree path in check_git_repository

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -227,7 +227,7 @@ fn check_git_repository(path: &Path) {
         .current_dir(path)
         .output()
         .unwrap();
-    if !output.status.success() {
+    if !output.status.success() || output.stdout == b"false\n" {
         panic!("not a git repository (or any of the parent directories)");
     }
 }


### PR DESCRIPTION
`git rev-parse --is-inside-work-tree` print false when running in `.git`