### PR TITLE
Index numbers

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -49,6 +49,7 @@ pub struct Commit {
     pub body: String,
     pub parent_commit_hashes: Vec<CommitHash>,
     pub commit_type: CommitType,
+    pub line_number: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -299,7 +300,7 @@ fn load_all_commits(
 
     let mut commits = Vec::new();
 
-    for bytes in reader.split(b'\0') {
+    for (i, bytes) in reader.split(b'\0').enumerate() {
         let bytes = bytes.unwrap();
         let s = String::from_utf8_lossy(&bytes);
 
@@ -320,6 +321,7 @@ fn load_all_commits(
             body: parts[8].into(),
             parent_commit_hashes: parse_parent_commit_hashes(parts[9]),
             commit_type: CommitType::Commit,
+            line_number: i,
         };
 
         commits.push(commit);
@@ -349,7 +351,7 @@ fn load_all_stashes(path: &Path) -> Vec<Commit> {
 
     let mut commits = Vec::new();
 
-    for bytes in reader.split(b'\0') {
+    for (i, bytes) in reader.split(b'\0').enumerate() {
         let bytes = bytes.unwrap();
         let s = String::from_utf8_lossy(&bytes);
 
@@ -370,6 +372,7 @@ fn load_all_stashes(path: &Path) -> Vec<Commit> {
             body: parts[8].into(),
             parent_commit_hashes: parse_parent_commit_hashes(parts[9]),
             commit_type: CommitType::Stash,
+            line_number: i,
         };
 
         commits.push(commit);

--- a/src/widget/commit_list.rs
+++ b/src/widget/commit_list.rs
@@ -814,18 +814,29 @@ impl CommitList<'_> {
                         commit.subject.to_string()
                     };
 
+                    let line_number = commit.line_number + 1; // 1-based
+                    let prefix = format!("{:>4} | ", line_number);
+                    let subject_with_line = format!("{}{}", prefix, subject);
+
                     let sub_spans =
                         if let Some(pos) = state.search_matches[state.offset + i].subject.clone() {
+                            let prefix_len = prefix.len();
+                            let shifted_pos = SearchMatchPosition::new(
+                                pos.matched_indices
+                                    .iter()
+                                    .map(|&idx| idx + prefix_len)
+                                    .collect(),
+                            );
                             highlighted_spans(
-                                subject.into(),
-                                pos,
+                                subject_with_line.into(),
+                                shifted_pos,
                                 self.ctx.color_theme.list_subject_fg,
                                 Modifier::empty(),
                                 &self.ctx.color_theme,
                                 truncate,
                             )
                         } else {
-                            vec![subject.fg(self.ctx.color_theme.list_subject_fg)]
+                            vec![subject_with_line.fg(self.ctx.color_theme.list_subject_fg)]
                         };
 
                     spans.extend(sub_spans)


### PR DESCRIPTION
Summary
Adds sequential line numbers to every commit displayed in the git tree view, providing users with a quick visual reference for commit ordering and easier navigation through commit history.
Will work well with the prefix navigation to aid in traversing up and down large git trees

<img width="773" height="491" alt="image" src="https://github.com/user-attachments/assets/577ef2bc-4fd4-40a8-a1a3-0eb5c9152777" />
