### PR TITLE
Reduce unnecessary margins from graph images

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -313,6 +313,15 @@
       "type": "object",
       "description": "Commit graph rendering settings",
       "properties": {
+        "row_image_width": {
+          "type": "string",
+          "description": "The width mode for each graph row image.",
+          "enum": [
+            "compact",
+            "fixed"
+          ],
+          "default": "compact"
+        },
         "color": {
           "type": "object",
           "description": "Colors for the commit graph.",

--- a/docs/src/configurations/config-file-format.md
+++ b/docs/src/configurations/config-file-format.md
@@ -43,6 +43,9 @@ height = 20
 [ui.refs]
 width = 26
 
+[graph]
+row_image_width = "compact"
+
 [graph.color]
 branches = [
   "#E06C76",
@@ -166,6 +169,18 @@ The initial selection of commit when starting the application.
   - `head`
 
 The value specified in the command line argument takes precedence.
+
+### `graph.row_image_width`
+
+The width mode for each graph row image.
+
+- type: `string` (enum)
+- default: `compact`
+- possible values:
+  - `compact`: trim each row image to the minimum required graph width
+    - Reduces the file size for more lightweight operation. If you are using `kitty-unicode` protocol, it helps you avoid hitting [the image transfer size limit](https://sw.kovidgoyal.net/kitty/graphics-protocol/#image-persistence-and-storage-quotas).
+  - `fixed`: use the same full graph width for every row image
+    - This can be used when you want to set a background color for graphs in environments that cannot correctly handle transparent images, or in environments where rendering does not work well when there are images of various widths.
 
 ### `core.search.ignore_case`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use umbra::optional;
 
 use crate::{
     color::{ColorTheme, OptionalColorTheme},
+    graph::GraphImageWidthMode,
     keybind::KeyBind,
     CommitOrderType, GraphStyle, GraphWidthType, ImageProtocolType, InitialSelection, Result,
 };
@@ -381,8 +382,11 @@ pub struct UiRefsConfig {
 }
 
 #[optional(derives = [Deserialize])]
-#[derive(Debug, Default, Clone, PartialEq, Eq, Validate)]
+#[derive(Debug, Clone, PartialEq, Eq, SmartDefault, Validate)]
 pub struct GraphConfig {
+    #[garde(skip)]
+    #[default(GraphImageWidthMode::Compact)]
+    pub row_image_width: GraphImageWidthMode,
     #[garde(dive)]
     #[nested]
     pub color: GraphColorConfig,
@@ -480,6 +484,7 @@ mod tests {
                 refs: UiRefsConfig { width: 26 },
             },
             graph: GraphConfig {
+                row_image_width: GraphImageWidthMode::Compact,
                 color: GraphColorConfig {
                     branches: vec![
                         "#E06C76".into(),
@@ -534,6 +539,8 @@ mod tests {
             height = 30
             [ui.refs]
             width = 40
+            [graph]
+            row_image_width = "fixed"
             [graph.color]
             branches = ["#ff0000", "#00ff00", "#0000ff"]
             edge = "#000000"
@@ -629,6 +636,7 @@ mod tests {
                 refs: UiRefsConfig { width: 40 },
             },
             graph: GraphConfig {
+                row_image_width: GraphImageWidthMode::Fixed,
                 color: GraphColorConfig {
                     branches: vec!["#ff0000".into(), "#00ff00".into(), "#0000ff".into()],
                     edge: "#000000".into(),
@@ -712,6 +720,7 @@ mod tests {
                 refs: UiRefsConfig { width: 26 },
             },
             graph: GraphConfig {
+                row_image_width: GraphImageWidthMode::Compact,
                 color: GraphColorConfig {
                     branches: vec![
                         "#E06C76".into(),

--- a/src/graph/image.rs
+++ b/src/graph/image.rs
@@ -24,6 +24,13 @@ pub enum GraphStyle {
     Angular,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GraphImageWidthMode {
+    Compact,
+    Fixed,
+}
+
 #[derive(Debug)]
 pub struct GraphImageManager<'a> {
     prepared_image_map: FxHashMap<CommitHash, PreparedImage>,
@@ -33,6 +40,7 @@ pub struct GraphImageManager<'a> {
     graph: &'a Graph<'a>,
     cell_width_type: CellWidthType,
     graph_style: GraphStyle,
+    image_width_mode: GraphImageWidthMode,
     image_params: ImageParams,
     drawing_pixels: DrawingPixels,
     image_protocol: ImageProtocol,
@@ -45,6 +53,7 @@ impl<'a> GraphImageManager<'a> {
         graph_color_set: &GraphColorSet,
         cell_width_type: CellWidthType,
         graph_style: GraphStyle,
+        image_width_mode: GraphImageWidthMode,
         image_protocol: ImageProtocol,
     ) -> Self {
         let image_params = ImageParams::new(graph_color_set, cell_width_type);
@@ -57,6 +66,7 @@ impl<'a> GraphImageManager<'a> {
             graph,
             cell_width_type,
             graph_style,
+            image_width_mode,
             image_params,
             drawing_pixels,
             image_protocol,
@@ -86,6 +96,7 @@ impl<'a> GraphImageManager<'a> {
             &self.image_params,
             &self.drawing_pixels,
             self.graph_style,
+            self.image_width_mode,
             commit_hash,
         );
         let mut image =
@@ -214,12 +225,18 @@ fn build_single_graph_row_image(
     image_params: &ImageParams,
     drawing_pixels: &DrawingPixels,
     graph_style: GraphStyle,
+    image_width_mode: GraphImageWidthMode,
     commit_hash: &CommitHash,
 ) -> GraphRowImage {
     let (pos_x, pos_y) = graph.commit_pos_map[&commit_hash];
     let edges = &graph.edges[pos_y];
 
-    let cell_count = graph.max_pos_x + 1;
+    let max_pos_x = match image_width_mode {
+        GraphImageWidthMode::Compact => edges.iter().map(|e| e.pos_x).fold(pos_x, usize::max),
+        GraphImageWidthMode::Fixed => graph.max_pos_x,
+    };
+
+    let cell_count = max_pos_x + 1;
 
     calc_graph_row_image(
         pos_x,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub fn run() -> Result<()> {
     let order = args.order.or(core_config.option.order).into();
     let graph_width = args.graph_width.or(core_config.option.graph_width);
     let graph_style = args.graph_style.or(core_config.option.graph_style).into();
+    let graph_image_width_mode = graph_config.row_image_width;
     let initial_selection = args
         .initial_selection
         .or(core_config.option.initial_selection)
@@ -173,6 +174,7 @@ pub fn run() -> Result<()> {
             &graph_color_set,
             cell_width_type,
             graph_style,
+            graph_image_width_mode,
             image_protocol,
         );
 


### PR DESCRIPTION
The following is a visualization using `graph.color.background = "#FFFFFFFF"`:

`graph.row_image_width = fixed` (same as previous implementations)

<img width="500" alt="fixed" src="https://github.com/user-attachments/assets/7fb9a6d8-d3b5-4af5-bbbc-04e7beda3d5d" />

`graph.row_image_width = compact` (new default implementation)

<img width="500"  alt="compact" src="https://github.com/user-attachments/assets/41568ce7-deb0-4069-8c1b-6f024e6f76df" />
