### PR TITLE
Add --watch and --fetch flags for auto-refreshing the view

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Options:
   -g, --graph-width <TYPE>        Commit graph image cell width [default: auto] [possible values: auto, double, single]
   -s, --graph-style <TYPE>        Commit graph image edge style [default: rounded] [possible values: rounded, angular]
   -i, --initial-selection <TYPE>  Initial selection of commit [default: latest] [possible values: latest, head]
+      --watch [<SECONDS>]         Auto-refresh the view on an interval (seconds) [default: 30]
+      --fetch                     Run `git fetch --all` before each auto-refresh (implies --watch)
   -h, --help                      Print help
   -V, --version                   Print version
 ```

--- a/docs/src/getting-started/command-line-options.md
+++ b/docs/src/getting-started/command-line-options.md
@@ -66,3 +66,29 @@ _Possible values:_ `latest`, `head`
 `latest` will select the latest commit.
 
 `head` will select the commit at HEAD.
+
+## --watch \[\<SECONDS\>\]
+
+Enable automatic refresh of the view on a fixed interval.
+
+If passed without a value, the interval defaults to 30 seconds.
+Values below 5 seconds are clamped to 5.
+
+The refresh only re-reads local git state — it does not contact any remote.
+External git activity (commits made in another terminal, fetches done by
+another tool) is picked up automatically as soon as it lands on disk.
+
+The current cursor / scroll position is preserved across refreshes.
+Ticks that arrive while you are typing in the search prompt are silently
+skipped so they do not interrupt input.
+
+## --fetch
+
+Run `git fetch --all --quiet` before each auto-refresh tick.
+
+Implies `--watch`: if `--watch` is not specified, the interval defaults
+to 30 seconds. Combine with `--watch <SECONDS>` to override.
+
+Fetch errors (network unreachable, authentication failures, etc.) are
+silently ignored so the refresh tick still fires with whatever local
+state is available.

--- a/src/app.rs
+++ b/src/app.rs
@@ -269,6 +269,14 @@ impl App<'_> {
                     let request = RefreshRequest { context };
                     return Ok(Ret::Refresh(request));
                 }
+                AppEvent::AutoRefresh => {
+                    // Skip ticks that arrive while the user is typing in the status line
+                    // (e.g. a search query) so we don't tear down their input.
+                    if matches!(self.app_status.status_line, StatusLine::Input(_, _, _)) {
+                        continue;
+                    }
+                    self.view.refresh();
+                }
                 AppEvent::ClearStatusLine => {
                     self.clear_status_line();
                 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::{self, Debug, Formatter},
+    process::{Command, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc, Arc, Mutex,
@@ -83,12 +84,13 @@ pub struct EventController {
     stop: Arc<AtomicBool>,
     handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
     watch_interval: Option<Duration>,
+    watch_fetch: bool,
     watch_stop: Arc<AtomicBool>,
     watch_handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
 }
 
 impl EventController {
-    pub fn init(watch_interval: Option<Duration>) -> Self {
+    pub fn init(watch_interval: Option<Duration>, watch_fetch: bool) -> Self {
         let (tx, rx) = mpsc::channel();
         let tx = Sender { tx };
         let rx = Receiver { rx };
@@ -99,6 +101,7 @@ impl EventController {
             stop: Arc::new(AtomicBool::new(false)),
             handle: Arc::new(Mutex::new(None)),
             watch_interval,
+            watch_fetch,
             watch_stop: Arc::new(AtomicBool::new(false)),
             watch_handle: Arc::new(Mutex::new(None)),
         };
@@ -144,6 +147,7 @@ impl EventController {
             self.watch_stop.store(false, Ordering::Relaxed);
             let stop = self.watch_stop.clone();
             let tx = self.tx.clone();
+            let fetch = self.watch_fetch;
             let handle = thread::spawn(move || loop {
                 // Sleep in small slices so we react to stop within ~100ms.
                 let mut remaining = interval;
@@ -154,6 +158,18 @@ impl EventController {
                     let slice = remaining.min(Duration::from_millis(100));
                     thread::sleep(slice);
                     remaining = remaining.saturating_sub(slice);
+                }
+                if stop.load(Ordering::Relaxed) {
+                    return;
+                }
+                if fetch {
+                    // Best-effort: ignore network / auth failures so the
+                    // refresh tick still fires.
+                    let _ = Command::new("git")
+                        .args(["fetch", "--all", "--quiet"])
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status();
                 }
                 if stop.load(Ordering::Relaxed) {
                     return;

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,6 +5,7 @@ use std::{
         mpsc, Arc, Mutex,
     },
     thread,
+    time::Duration,
 };
 
 use ratatui::crossterm::event::KeyEvent;
@@ -33,6 +34,7 @@ pub enum AppEvent {
     SelectParentCommit,
     CopyToClipboard { name: String, value: String },
     Refresh(RefreshViewContext),
+    AutoRefresh,
     ClearStatusLine,
     UpdateStatusInput(String, Option<u16>, Option<String>),
     NotifyInfo(String),
@@ -80,10 +82,13 @@ pub struct EventController {
     rx: Receiver,
     stop: Arc<AtomicBool>,
     handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
+    watch_interval: Option<Duration>,
+    watch_stop: Arc<AtomicBool>,
+    watch_handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
 }
 
 impl EventController {
-    pub fn init() -> Self {
+    pub fn init(watch_interval: Option<Duration>) -> Self {
         let (tx, rx) = mpsc::channel();
         let tx = Sender { tx };
         let rx = Receiver { rx };
@@ -93,6 +98,9 @@ impl EventController {
             rx,
             stop: Arc::new(AtomicBool::new(false)),
             handle: Arc::new(Mutex::new(None)),
+            watch_interval,
+            watch_stop: Arc::new(AtomicBool::new(false)),
+            watch_handle: Arc::new(Mutex::new(None)),
         };
         controller.start();
 
@@ -131,6 +139,29 @@ impl EventController {
             }
         });
         *self.handle.lock().unwrap() = Some(handle);
+
+        if let Some(interval) = self.watch_interval {
+            self.watch_stop.store(false, Ordering::Relaxed);
+            let stop = self.watch_stop.clone();
+            let tx = self.tx.clone();
+            let handle = thread::spawn(move || loop {
+                // Sleep in small slices so we react to stop within ~100ms.
+                let mut remaining = interval;
+                while remaining > Duration::ZERO {
+                    if stop.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let slice = remaining.min(Duration::from_millis(100));
+                    thread::sleep(slice);
+                    remaining = remaining.saturating_sub(slice);
+                }
+                if stop.load(Ordering::Relaxed) {
+                    return;
+                }
+                tx.send(AppEvent::AutoRefresh);
+            });
+            *self.watch_handle.lock().unwrap() = Some(handle);
+        }
     }
 
     pub fn resume(&self) {
@@ -159,6 +190,10 @@ impl EventController {
     fn stop(&self) {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.handle.lock().unwrap().take() {
+            handle.join().unwrap();
+        }
+        self.watch_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.watch_handle.lock().unwrap().take() {
             handle.join().unwrap();
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -164,9 +164,13 @@ impl EventController {
                 }
                 if fetch {
                     // Best-effort: ignore network / auth failures so the
-                    // refresh tick still fires.
+                    // refresh tick still fires. Force non-interactive so
+                    // the fetch can't hang on a prompt the user can't see
+                    // (TUI owns the terminal).
                     let _ = Command::new("git")
                         .args(["fetch", "--all", "--quiet"])
+                        .env("GIT_TERMINAL_PROMPT", "0")
+                        .stdin(Stdio::null())
                         .stdout(Stdio::null())
                         .stderr(Stdio::null())
                         .status();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,10 @@ struct Args {
     /// Initial selection of commit [default: latest]
     #[arg(short, long, value_name = "TYPE")]
     initial_selection: Option<InitialSelection>,
+
+    /// Auto-refresh the view on an interval (seconds) [default: 30]
+    #[arg(long, value_name = "SECONDS", num_args = 0..=1, default_missing_value = "30")]
+    watch: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -158,7 +162,8 @@ pub fn run() -> Result<()> {
         image_protocol,
     });
 
-    let ec = event::EventController::init();
+    let watch_interval = args.watch.map(|s| std::time::Duration::from_secs(s.max(5)));
+    let ec = event::EventController::init(watch_interval);
     let mut refresh_view_context = None;
     let mut terminal = None;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,10 @@ struct Args {
     /// Auto-refresh the view on an interval (seconds) [default: 30]
     #[arg(long, value_name = "SECONDS", num_args = 0..=1, default_missing_value = "30")]
     watch: Option<u64>,
+
+    /// Run `git fetch --all` before each auto-refresh (implies --watch)
+    #[arg(long)]
+    fetch: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -162,8 +166,9 @@ pub fn run() -> Result<()> {
         image_protocol,
     });
 
-    let watch_interval = args.watch.map(|s| std::time::Duration::from_secs(s.max(5)));
-    let ec = event::EventController::init(watch_interval);
+    let watch_seconds = args.watch.or(if args.fetch { Some(30) } else { None });
+    let watch_interval = watch_seconds.map(|s| std::time::Duration::from_secs(s.max(5)));
+    let ec = event::EventController::init(watch_interval, args.fetch);
     let mut refresh_view_context = None;
     let mut terminal = None;
 


### PR DESCRIPTION
I added these flags because I like to have `serie` running on the side so I don't miss any updates to the repo while I am working on something else.

## Summary

- Add `--watch [<SECONDS>]` (default 30s when bare, minimum 5s) that periodically re-runs the existing refresh path so external git activity shows up automatically. Cursor and scroll state are preserved across refreshes via the existing `RefreshViewContext`.
- Add `--fetch` flag that implies `--watch` (defaulting to 30s) and runs `git fetch --all --quiet` on the watch worker thread before each tick. Fetch errors (offline, auth) are silently ignored so the refresh still fires. The fetch is forced fully non-interactive (`GIT_TERMINAL_PROMPT=0`, stdin closed) so it can't hang on a prompt the TUI hides.
- Reuses the existing manual-refresh machinery end-to-end: a new `AppEvent::AutoRefresh` is handled in `app.rs`'s main loop by calling the active view's existing `refresh()` method, which emits the same `AppEvent::Refresh(context)` that pressing `r` produces today. The watch worker thread stops/starts alongside the key-poll thread on suspend/resume, so `suspend`-type user commands (e.g. `vim`) cleanly pause the timer.
- Docs: `README.md` `--help` block and `docs/src/getting-started/command-line-options.md` updated.

## Test plan

- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] `cargo test` — 45 unit + 19 integration tests pass
- [x] `--help` shows both new flags
- [x] Manual TUI test: `serie --watch 5` + external commit in another terminal → new commit appears within ~5s, cursor preserved
- [x] Manual TUI test: `serie --watch 5 --fetch` against an SSH remote → pulls down upstream commits without manual `git fetch`
- [ ] Manual TUI test: typing in `/`-search prompt while AutoRefresh ticks → input not torn down (skipped via `StatusLine::Input` guard)
- [ ] Manual TUI test: `suspend`-type user command (e.g. vim) → timer paused during suspend, resumes on return